### PR TITLE
Fixups

### DIFF
--- a/benchmarks/ak-editor/.parcelrc
+++ b/benchmarks/ak-editor/.parcelrc
@@ -1,7 +1,4 @@
 {
   "extends": "@parcel/config-default",
-  "reporters": ["...", "@parcel/reporter-build-metrics"],
-  "transforms": {
-    "*.js": ["@parcel/transformer-babel", "..."]
-  }
+  "reporters": ["...", "@parcel/reporter-build-metrics"]
 }

--- a/benchmarks/ak-editor/benchmark-config.json
+++ b/benchmarks/ak-editor/benchmark-config.json
@@ -1,4 +1,0 @@
-{
-  "entrypoint": "src/index.js",
-  "outputDir": "dist"
-}

--- a/benchmarks/ak-editor/package.json
+++ b/benchmarks/ak-editor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@parcel/ak-editor-benchmark",
   "version": "1.0.0",
+  "source": "src/index.js",
   "license": "MIT",
   "dependencies": {
     "@atlaskit/css-reset": "^5.0.9",

--- a/benchmarks/kitchen-sink/.parcelrc
+++ b/benchmarks/kitchen-sink/.parcelrc
@@ -1,7 +1,4 @@
 {
   "extends": "@parcel/config-default",
-  "reporters": ["...", "@parcel/reporter-build-metrics"],
-  "transforms": {
-    "*.js": ["@parcel/transformer-babel", "..."]
-  }
+  "reporters": ["...", "@parcel/reporter-build-metrics"]
 }

--- a/benchmarks/kitchen-sink/benchmark-config.json
+++ b/benchmarks/kitchen-sink/benchmark-config.json
@@ -1,4 +1,0 @@
-{
-  "entrypoint": "src/index.js",
-  "outputDir": "dist"
-}

--- a/benchmarks/kitchen-sink/package.json
+++ b/benchmarks/kitchen-sink/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "parcel build src/index.html"
   },
+  "source": "src/index.html",
   "appLegacy": "dist/legacy/index.html",
   "appModern": "dist/modern/index.html",
   "targets": {

--- a/benchmarks/react-hn/.parcelrc
+++ b/benchmarks/react-hn/.parcelrc
@@ -1,7 +1,4 @@
 {
   "extends": "@parcel/config-default",
-  "reporters": ["...", "@parcel/reporter-build-metrics"],
-  "transforms": {
-    "*.js": ["@parcel/transformer-babel", "..."]
-  }
+  "reporters": ["...", "@parcel/reporter-build-metrics"]
 }

--- a/benchmarks/react-hn/benchmark-config.json
+++ b/benchmarks/react-hn/benchmark-config.json
@@ -1,4 +1,0 @@
-{
-  "entrypoint": "src/index.js",
-  "outputDir": "dist"
-}

--- a/benchmarks/react-hn/package.json
+++ b/benchmarks/react-hn/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "http://github.com/insin/react-hn.git"
   },
+  "source": "src/index.js",
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",
   "devDependencies": {

--- a/src/utils/benchmark.ts
+++ b/src/utils/benchmark.ts
@@ -36,7 +36,6 @@ export type BuildMetrics = {
 
 type BuildOpts = {
   dir: string;
-  entrypoint: string;
   cache?: boolean;
 };
 
@@ -49,7 +48,7 @@ const FALLBACK_METRICS = {
 
 async function runBuild(options: BuildOpts, isRetry: boolean = false): Promise<BuildMetrics | null> {
   try {
-    let args = ['run', 'parcel', 'build', options.entrypoint, '--log-level', 'warn'];
+    let args = ['run', 'parcel', 'build', '.', '--log-level', 'warn'];
     if (!options.cache) {
       args.push('--no-cache');
     }
@@ -65,7 +64,7 @@ async function runBuild(options: BuildOpts, isRetry: boolean = false): Promise<B
     return JSON.parse(await fs.readFile(path.join(options.dir, 'parcel-metrics.json'), 'utf8'));
   } catch (e) {
     if (isRetry) {
-      console.log('Failed to run parcel build:', path.join(options.dir, options.entrypoint));
+      console.log('Failed to run parcel build:', options.dir);
       return null;
     }
 
@@ -77,15 +76,12 @@ async function runBuild(options: BuildOpts, isRetry: boolean = false): Promise<B
 }
 
 export async function runBenchmark(exampleDir: string, name: string): Promise<Benchmark | null> {
-  let benchmarkConfig = require(path.join(exampleDir, 'benchmark-config.json'));
-
   let coldBuildMetrics = [];
   for (let i = 0; i < AMOUNT_OF_RUNS; i++) {
     console.log('Running cold build:', name);
 
     let metrics = await runBuild({
-      dir: exampleDir,
-      entrypoint: benchmarkConfig.entrypoint
+      dir: exampleDir
     });
 
     console.log('Finished cold build:', name);
@@ -101,8 +97,7 @@ export async function runBenchmark(exampleDir: string, name: string): Promise<Be
 
     let metrics = await runBuild({
       dir: exampleDir,
-      cache: true,
-      entrypoint: benchmarkConfig.entrypoint
+      cache: true
     });
 
     console.log('Finished cached build:', name);

--- a/src/utils/send-results.ts
+++ b/src/utils/send-results.ts
@@ -1,6 +1,5 @@
 import fetch from 'node-fetch';
 import urlJoin from 'url-join';
-import { captureException } from '@sentry/node';
 
 import { Comparisons } from './compare-benchmarks';
 import { API_URL } from '../constants';


### PR DESCRIPTION
- `transforms` was renamed, but that shouldn't be needed anyway?
- use `pkg#source` instead of specifying in `benchmark-config.json`, which can now be removed (`buildDir` was never used)