### PR TITLE
fix github action benchmark

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash -l
 
 set -eu # stop on error
 cd /usr/src/app/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,5 @@
-#!/bin/bash -l
+#!/bin/sh
 
-ls -lah /root
-cat /root/.bashrc
-echo $PATH
-echo $HOME
 set -eu # stop on error
 cd /usr/src/app/
 yarn action-start

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# rust is installed in root HOME, certain rustup commands depends on $HOME Environment variable to find ~/.cargo
+# GitHub Actions sets HOME to /github/home which breaks rustup
+export HOME=/root
 set -eu # stop on error
 cd /usr/src/app/
 yarn action-start

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -l
 
+ls -lah /root
+cat /root/.bashrc
+echo $PATH
+echo $HOME
 set -eu # stop on error
 cd /usr/src/app/
 yarn action-start


### PR DESCRIPTION
Okay so the problem was because GitHub Actions sets `HOME=/github/home`
with `sh -l` it loads `/etc/profile` then loads either `~/.bash_profile` `~/.bash_login` or `~/.profile`, I'm guessing `/etc/profile` contains entry that overrides the `PATH` provided by Docker, and since `HOME` is changed to `/github/home` it will never find `/root/.bashrc`

[shell load file chart](https://miro.medium.com/max/611/1*3lQ7QudhPBIUVdi_xKfhFg.png)

---
did some test locally.

- add `env` to `entrypoint.sh`, build Docker file, ran the image, `env` shows `PATH` contains `/root/.cargo/bin`.

- add `env` to `entrypoint.sh`, modify Docker file to
```
ENV PATH=/root/.cargo/bin:$PATH
ENV USER root
ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
```
, ran the image, `env` shows `PATH` does NOT contains `/root/.cargo/bin`.

- add `env` to `entrypoint.sh` and change `#!/bin/sh -l` to `#!/bin/sh`, modify Docker file to
```
ENV PATH=/root/.cargo/bin:$PATH
ENV USER root
ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
```
, ran the image, `env` shows `PATH` contains `/root/.cargo/bin`.

- add `env` to `entrypoint.sh` and change `#!/bin/sh -l` to `#!/bin/bash`, modify Docker file to
```
ENV PATH=/root/.cargo/bin:$PATH
ENV USER root
RUN echo CUSTOM=test >> /root/.bashrc
ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
```
, ran the image, `env` does NOT show `CUSTOM`.

- add `env` to `entrypoint.sh` and change `#!/bin/sh -l` to `#!/bin/bash -l`, modify Docker file to
```
ENV PATH=/root/.cargo/bin:$PATH
ENV USER root
RUN echo CUSTOM=test >> /root/.bashrc
ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
```
, ran the image, `env`  show `CUSTOM`.

# summary
- there's some odd reason that the docker file works fine locally without any modifications but breaks on GitHub Actions.
- `#!/bin/sh -l` discards the environment variables set by dockerfile if we don't run other stuff besides setting the `ENV`
- `#!/bin/sh` does NOT discard the environment variables set by dockerfile if we don't run other stuff besides setting the `ENV
- `#!/bin/bash` does NOT load .bashrc
- `#!/bin/sh` or `#!/bin/sh -l` does NOT load .bashrc
- `#!/bin/bash -l` loads .bashrc

hope this is able to fix it.