### PR TITLE
Update docker base image (node:14.16.1 => node:14.18.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.1
+FROM node:14.18.0
 
 LABEL com.github.actions.name="Parcel Benchmark Action"
 LABEL com.github.actions.description="Measures performance impact of a PR"


### PR DESCRIPTION
To fix `docker build` fails in CI of parcel-bundler/parcel, bump up base image to latest of v14.
https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/ is related.

```console
$ docker run --rm -it --entrypoint /bin/bash node:14.16.1

root@b5a68ae2a0ea:/# apt-get update 2>&1>/dev/null && apt-get install --no-install-recommends -y ca-certificates curl > /dev/null
debconf: delaying package configuration, since apt-utils is not installed
root@b5a68ae2a0ea:/# curl -sS https://www.openssl.org/source/openssl-1.0.2k.tar.gz > /dev/null
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```

`node:14.18.0`: ok

```console
root@626752ac8668:/# apt-get update 2>&1>/dev/null && apt-get install --no-install-recommends -y ca-certificates curl > /dev/null
debconf: delaying package configuration, since apt-utils is not installed
root@626752ac8668:/# curl -sS https://www.openssl.org/source/openssl-1.0.2k.tar.gz > /dev/null
root@626752ac8668:/# echo $?
0
```