### PR TITLE
docker: node 18.15.0, openssl 1.1.1t

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.0
+FROM node:18.15.0
 
 LABEL com.github.actions.name="Parcel Benchmark Action"
 LABEL com.github.actions.description="Measures performance impact of a PR"
@@ -11,7 +11,7 @@ RUN apt-get update && \
     autoconf automake autotools-dev libtool xutils-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ENV SSL_VERSION=1.0.2k
+ENV SSL_VERSION=1.1.1t
 
 RUN curl https://www.openssl.org/source/openssl-$SSL_VERSION.tar.gz -O && \
     tar -xzf openssl-$SSL_VERSION.tar.gz && \


### PR DESCRIPTION
The image no longer builds,making the action fail.

Example: https://github.com/parcel-bundler/parcel/actions/runs/4934084435/jobs/8818728873?pr=8997

This updates nodejs to latest LTS and bumps openssl to 1.1.1t.

As this will affect benchmark results, I guess it makes sense to treat it as a breaking change.

Related conservative version which could be considered for a minor release: #94 