### PR TITLE
docker: change base image to node:14.21.3-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.0
+FROM node:14.21.3-bullseye
 
 LABEL com.github.actions.name="Parcel Benchmark Action"
 LABEL com.github.actions.description="Measures performance impact of a PR"


### PR DESCRIPTION
The image no longer builds, making the action fail.

Example: https://github.com/parcel-bundler/parcel/actions/runs/4934084435/jobs/8818728873?pr=8997

This changes the base image to one based on Debian bullseye (current stable) as opposed to jessie, while keeping the Node.js version at (currently EoL) 14.

Related breaking change for a major release: #93 