### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmarks/kitchen-sink/package.json
+++ b/benchmarks/kitchen-sink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/kitchen-sink-benchmark",
-  "version": "2.0.0-alpha.1.1",
+  "version": "2.9.3",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -26,9 +26,9 @@
     }
   },
   "devDependencies": {
-    "@parcel/reporter-build-metrics": "^2.0.0-alpha.1.1",
-    "@parcel/transformer-image": "^2.0.0-alpha.1.1",
-    "parcel": "^2.0.0-alpha.1.1"
+    "@parcel/reporter-build-metrics": "^2.9.3",
+    "@parcel/transformer-image": "^2.9.3",
+    "parcel": "^2.9.3"
   },
   "dependencies": {
     "lodash": "^4.17.11",

--- a/benchmarks/react-hn/package.json
+++ b/benchmarks/react-hn/package.json
@@ -17,10 +17,10 @@
     "@babel/plugin-proposal-function-bind": "^7.12.13",
     "@babel/preset-env": "^7.13.9",
     "@babel/preset-react": "^7.12.13",
-    "@parcel/reporter-build-metrics": "^2.0.0-alpha.1.1",
-    "@parcel/transformer-image": "^2.0.0-alpha.1.1",
+    "@parcel/reporter-build-metrics": "^2.9.3",
+    "@parcel/transformer-image": "^2.9.3",
     "core-js": "^3.9.1",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.9.3"
   },
   "dependencies": {
     "events": "1.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ async function setupParcel(opts: { repoUrl: string; branch: string; outputDir: s
       let pkgContent = await fs.readFile(pkgFilePath, 'utf-8');
       let parsedPkgContent = JSON.parse(pkgContent);
       let pkgName = parsedPkgContent.name;
-      if (pkgName === 'parcel' || pkgName.startsWith('@parcel')) {
+      if (pkgName && (pkgName === 'parcel' || pkgName.startsWith('@parcel'))) {
         packageMap.set(parsedPkgContent.name, path.dirname(pkgFilePath));
       }
     });


### PR DESCRIPTION
Benchmark build in PRs has been failing due to a package with no name (`packages/utils/create-react-app/templates/package.json`). This PR skips packages with no names to avoid the issue.

In addition, some dependencies on old Parcel versions were updated as some of the old deps failed to build on an M1 Mac when testing.