### PR TITLE
Add benchmark debug logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf .tmp .parcel-cache github node_modules yarn.lock",
     "build": "tsc",
     "watch": "tsc -w",
-    "start": "NODE_ENV=development node src/index",
+    "start": "NODE_ENV=development ts-node src/index",
     "action-start": "ts-node src/index",
     "docker-build": "docker build -t parcel/benchmark .",
     "docker-start": "docker run -i -t parcel/benchmark",

--- a/src/utils/compare-benchmarks.ts
+++ b/src/utils/compare-benchmarks.ts
@@ -35,6 +35,14 @@ export interface Comparison {
 export type Comparisons = Array<Comparison>;
 
 export function compareMetrics(base: BuildMetrics, comparison: BuildMetrics, testDir: string): BuildComparison {
+  if (process.env.ACTIONS_STEP_DEBUG === 'true') {
+    console.log('\nBase metrics:');
+    console.log(JSON.stringify(base, null, 2));
+    console.log('\nComparison metrics:');
+    console.log(JSON.stringify(comparison, null, 2));
+    console.log('\n');
+  }
+
   return {
     buildTime: comparison.buildTime,
     buildTimeDiff: comparison.buildTime - base.buildTime,


### PR DESCRIPTION
Allows using Github Action debugging to get additional data of the data being compared to try and resolve an issue with the Action that doesn't occur locally.