### PR TITLE
Use modern node image to fix openssl failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:18.15.0
+FROM node:22.4-bullseye
 
 LABEL com.github.actions.name="Parcel Benchmark Action"
-LABEL com.github.actions.description="Measures performance impact of a PR"
-LABEL repository="https://github.com/DeMoorJasper/parcel-benchmark-action"
+LABEL com.github.actions.description="Measures performance impact of a pull request"
+LABEL repository="https://github.com/parcel-bundler/parcel-benchmark-action"
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
@@ -11,19 +11,8 @@ RUN apt-get update && \
     autoconf automake autotools-dev libtool xutils-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ENV SSL_VERSION=1.1.1t
-
-RUN curl https://www.openssl.org/source/openssl-$SSL_VERSION.tar.gz -O && \
-    tar -xzf openssl-$SSL_VERSION.tar.gz && \
-    cd openssl-$SSL_VERSION && ./config && make depend && make install && \
-    cd .. && rm -rf openssl-$SSL_VERSION*
-
-ENV OPENSSL_LIB_DIR=/usr/local/ssl/lib \
-    OPENSSL_INCLUDE_DIR=/usr/local/ssl/include \
-    OPENSSL_STATIC=1
-
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain nightly -y
+    sh -s -- --default-toolchain stable -y
 
 ENV PATH=/root/.cargo/bin:$PATH
 ENV USER root


### PR DESCRIPTION
These changes should resolve the following error in parcel builds:

> ERROR: failed to solve: process "/bin/sh -c curl https://www.openssl.org/source/openssl-$SSL_VERSION.tar.gz -O &&     tar -xzf openssl-$SSL_VERSION.tar.gz &&     cd openssl-$SSL_VERSION && ./config && make depend && make install &&     cd .. && rm -rf openssl-$SSL_VERSION*" did not complete successfully: exit code: 2